### PR TITLE
Fix TypeError on app init

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,7 +18,7 @@
         "devDependencies": true
       }
     ],
-    "no-unused-vars": "warn",
+    "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "next" }],
     "import/prefer-default-export": "off"
   },
   "settings": {

--- a/src/server/middlewares/errorHandler.ts
+++ b/src/server/middlewares/errorHandler.ts
@@ -1,14 +1,14 @@
 import { BAD_REQUEST, INTERNAL_SERVER_ERROR } from 'http-status';
 import { ValidationError as ExpressValidationError } from 'express-validation';
 import { ValidationError as SequelizeValidationError } from 'sequelize';
-import { Request, Response } from 'express';
+import { Request, Response, NextFunction } from 'express';
 import BaseError from 'server/utils/errors/BaseError';
 import { createErrorResponse } from 'server/utils/functions';
 import errors from 'server/utils/constants/errors';
 
 type HandledError = BaseError | ExpressValidationError | SequelizeValidationError | Error;
 
-const errorHandler = (err: HandledError, req: Request, res: Response) => {
+const errorHandler = (err: HandledError, req: Request, res: Response, next: NextFunction) => {
   if (err instanceof BaseError) {
     return res
       .status(err.statusCode)


### PR DESCRIPTION
After run the app and access to localhost:8000 I'm getting this error:

![CleanShot 2021-06-08 at 20 11 33](https://user-images.githubusercontent.com/9404632/121239008-00913580-c899-11eb-98d3-44d85269a3bf.png)

Caused by missing `next` function on `errorHandler`. This will be not used on the function, but it's necessary to pass it as param. To avoid linter errors, [I have added a new rule](https://github.com/expressjs/generator/issues/78) (the unused-var rule was wrong too, now it's fixed)

